### PR TITLE
Fix tenpai status display for Suuankou wait

### DIFF
--- a/client/src/pages/game/components/tenpai-tiles.tsx
+++ b/client/src/pages/game/components/tenpai-tiles.tsx
@@ -2,7 +2,7 @@ import { FC } from 'react'
 import { Stack, Typography } from '@mui/material'
 import SketchBox from '@ima/client/components/sketch-box'
 import HaiCounter from '@ima/client/components/hai-counter'
-import { tenpaiStatusText } from '@ima/client/utils/game'
+import { getTenpaiStatusText } from '@ima/client/utils/game'
 import { compareSimpleTile } from '@ima/client/utils/tile'
 
 import type { Tenpai } from '@ima/server/types/tenpai'
@@ -34,7 +34,7 @@ const TenpaiTiles: FC<TenpaiTilesProps> = ({ list, current }) => {
             <Stack direction="column" gap="0.25vmin" key={[tenpai.agariTile.type, tenpai.agariTile.value].join()}>
               <HaiCounter tile={tenpai.agariTile} size={3} />
               <Typography fontSize="2vmin" align="left">
-                {tenpai.status === 'tenpai' ? `${tenpai.han}판` : tenpaiStatusText[tenpai.status]}
+                {getTenpaiStatusText(tenpai)}
               </Typography>
             </Stack>
           ))}

--- a/client/src/utils/game.ts
+++ b/client/src/utils/game.ts
@@ -56,11 +56,11 @@ export const tenpaiStatusText: Record<Tenpai['status'], string> = {
 }
 
 export const calculateTenpaiState = (list: Tenpai[]) => {
-  if (list.every((t) => t.han >= 13)) {
+  if (list.every((t) => t.han && t.han.tsumo >= 13 && t.han.ron >= 13)) {
     return { text: '역만 준비', color: '#fac12d', isYakuman: true }
   }
 
-  if (list.some((t) => t.han >= 13)) {
+  if (list.some((t) => t.han && (t.han.tsumo >= 13 || t.han.ron >= 13))) {
     return { text: '역만 기회', color: '#ccc', isYakuman: true }
   }
 
@@ -69,6 +69,15 @@ export const calculateTenpaiState = (list: Tenpai[]) => {
   }
 
   return undefined
+}
+
+export const getTenpaiStatusText = (tenpai: Tenpai) => {
+  if (tenpai.status === 'tenpai' && tenpai.han) {
+    const min = Math.min(tenpai.han.tsumo, tenpai.han.ron)
+    const max = Math.max(tenpai.han.tsumo, tenpai.han.ron)
+    return min === max ? `${max}판` : `${min}-${max}판`
+  }
+  return tenpaiStatusText[tenpai.status]
 }
 
 export const getAgariHaiSize = (hand: Hand) => {

--- a/server/src/helpers/yaku/index.ts
+++ b/server/src/helpers/yaku/index.ts
@@ -24,7 +24,7 @@ const calculateYakuOfAgari = (
   const agariTsu = agariState.find((tsu) => tsu.tiles.some((tile) => tile.index === agariTile.index))
   /* istanbul ignore next */ if (!agariTsu) return []
 
-  if (agariType === 'ron') agariTsu.open = true
+  if (agariType !== 'tsumo') agariTsu.open = true
 
   const opponent = getOpponent(me)
   const params: YakuPredicateParams = {

--- a/server/src/types/tenpai.ts
+++ b/server/src/types/tenpai.ts
@@ -6,5 +6,5 @@ export interface Tenpai {
   giriTile: Tile | null
   agariTile: SimpleTile
   status: TenpaiStatus
-  han: number
+  han?: { tsumo: number; ron: number }
 }


### PR DESCRIPTION
This pull request fixes the bug where the tenpai status for Suuankou wait was displayed as "역만 준비" instead of "역만 기회". The bug occurred when completing a triplet via ron, which should not be considered concealed. The fix includes changes to the `TenpaiTiles` component and the `calculateTenpaiState` function in the `game` utility file. Additionally, a new `getTenpaiStatusText` function is added to handle the display of the tenpai status. The changes ensure that the correct tenpai status is displayed for Suuankou wait, based on whether it can only win by tsumo or not.

Fixes #11